### PR TITLE
[Feature] 스케줄 등록/수정 비즈니스 로직 구현 및 뷰 바인딩, 스케줄 목록화면 개선

### DIFF
--- a/PersonalScheduler/Sources/Extensions/Date+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Date+extension.swift
@@ -11,7 +11,11 @@ extension Date {
     
     func toString(_ format: DateFormat) -> String {
         let formatter = DateFormatter()
+        formatter.timeZone = TimeZone.current
         formatter.dateFormat = format.rawValue
+        let localeID = Locale.preferredLanguages.first
+        let deviceLocale = Locale(identifier: localeID ?? "ko-kr").languageCode
+        formatter.locale = Locale(identifier: deviceLocale ?? "ko-kr")
         return formatter.string(from: self)
     }
     
@@ -59,4 +63,5 @@ enum DateFormat: String {
     case month = "M"
     case day = "d"
     case week = "E"
+    case yearAndMonth = "yyyy년 M월"
 }

--- a/PersonalScheduler/Sources/Extensions/Date+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Date+extension.swift
@@ -59,6 +59,7 @@ extension Date {
 
 enum DateFormat: String {
     case hourMinute = "a h:mm"
+    case hourMinuteDate = "a h:mm (M/d)"
     case yyyyMMddEEEE = "yyyy. MM. dd. EEEE"
     case month = "M"
     case day = "d"

--- a/PersonalScheduler/Sources/Extensions/Date+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Date+extension.swift
@@ -34,6 +34,23 @@ extension Date {
         return result == .orderedAscending
     }
     
+    func contains(start: Date, end: Date) -> Bool {
+        let period = start.timeIntervalSinceReferenceDate...end.timeIntervalSinceReferenceDate
+        return period.contains(self.timeIntervalSinceReferenceDate)
+    }
+    
+    func isEqualDay(from date: Date) -> Bool {
+        let lhs = Calendar.current.component(.day, from: self)
+        let rhs = Calendar.current.component(.day, from: date)
+        return lhs == rhs
+    }
+    
+    func isEqualMonth(from date: Date) -> Bool {
+        let lhs = Calendar.current.component(.month, from: self)
+        let rhs = Calendar.current.component(.month, from: date)
+        return lhs == rhs
+    }
+    
 }
 
 enum DateFormat: String {

--- a/PersonalScheduler/Sources/Extensions/Date+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Date+extension.swift
@@ -29,6 +29,11 @@ extension Date {
         return Date(timeIntervalSinceNow: self.timeIntervalSinceNow + Double((3600 * hour)))
     }
     
+    func isFuture(from date: Date) -> Bool {
+        let result: ComparisonResult = self.compare(date)
+        return result == .orderedAscending
+    }
+    
 }
 
 enum DateFormat: String {

--- a/PersonalScheduler/Sources/Extensions/Date+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Date+extension.swift
@@ -43,12 +43,6 @@ extension Date {
         return period.contains(self.timeIntervalSinceReferenceDate)
     }
     
-    func isEqualDay(from date: Date) -> Bool {
-        let lhs = Calendar.current.component(.day, from: self)
-        let rhs = Calendar.current.component(.day, from: date)
-        return lhs == rhs
-    }
-    
     func isEqualMonth(from date: Date) -> Bool {
         let lhs = Calendar.current.component(.month, from: self)
         let rhs = Calendar.current.component(.month, from: date)

--- a/PersonalScheduler/Sources/Extensions/Encodable+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/Encodable+extension.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
 
 extension Encodable {
 
@@ -15,6 +17,12 @@ extension Encodable {
         guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
             throw NSError()
         }
+        return dictionary
+    }
+    
+    func asFirestoreDictionary() throws -> [String: Any] {
+        let encoder = Firestore.Encoder()
+        let dictionary = try encoder.encode(self)
         return dictionary
     }
 

--- a/PersonalScheduler/Sources/Extensions/UIViewController+extension.swift
+++ b/PersonalScheduler/Sources/Extensions/UIViewController+extension.swift
@@ -15,8 +15,9 @@ extension UIViewController {
         self.present(alert, animated: true)
     }
     
-    func showDatePickerAlert(_ date: Date, handler: ((Date) -> Void)?) {
+    func showDatePickerAlert(_ date: Date, type: UIDatePicker.Mode = .dateAndTime, handler: ((Date) -> Void)?) {
         let datePicker = createDatePicker(date)
+        datePicker.datePickerMode = type
         let dateChooserAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         dateChooserAlert.view.addSubviews(datePicker)
         NSLayoutConstraint.activate([

--- a/PersonalScheduler/Sources/Model/Schedule.swift
+++ b/PersonalScheduler/Sources/Model/Schedule.swift
@@ -17,6 +17,10 @@ struct Schedule: Codable {
     var isProgressing: Bool {
         return Date().contains(start: startDate, end: endDate)
     }
+    
+    var hasOneMoreDay: Bool {
+        return startDate.toString(.yyyyMMddEEEE) != endDate.toString(.yyyyMMddEEEE)
+    }
 }
 
 extension Schedule {

--- a/PersonalScheduler/Sources/Model/Schedule.swift
+++ b/PersonalScheduler/Sources/Model/Schedule.swift
@@ -25,11 +25,32 @@ extension Schedule {
         self.description = description
     }
     
+    init() {
+        self.id = UUID().uuidString
+        self.title = ""
+        self.startDate = Date().nearestHour()
+        self.endDate = Date().nearestHour().plusHour(1)
+        self.description = ""
+    }
+    
+    init(_ dictinary: [String: Any]) {
+        self.id = dictinary["id"] as? String ?? UUID().uuidString
+        self.title = dictinary["title"] as? String ?? ""
+        self.startDate = dictinary["startDate"] as? Date ?? Date()
+        self.endDate = dictinary["endDate"] as? Date ?? Date()
+        self.description = dictinary["description"] as? String ?? ""
+    }
+    
 }
 
 extension Schedule: Equatable, Hashable {
+    
     static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.id == rhs.id &&
+        lhs.title == rhs.title &&
+        lhs.startDate == rhs.startDate &&
+        lhs.endDate == rhs.endDate &&
+        lhs.description == rhs.description
     }
     
     func hash(into hasher: inout Hasher) {

--- a/PersonalScheduler/Sources/Model/Schedule.swift
+++ b/PersonalScheduler/Sources/Model/Schedule.swift
@@ -13,6 +13,10 @@ struct Schedule: Codable {
     let startDate: Date
     let endDate: Date
     let description: String
+    
+    var isProgressing: Bool {
+        return Date().contains(start: startDate, end: endDate)
+    }
 }
 
 extension Schedule {
@@ -50,7 +54,8 @@ extension Schedule: Equatable, Hashable {
         lhs.title == rhs.title &&
         lhs.startDate == rhs.startDate &&
         lhs.endDate == rhs.endDate &&
-        lhs.description == rhs.description
+        lhs.description == rhs.description &&
+        lhs.isProgressing == rhs.isProgressing
     }
     
     func hash(into hasher: inout Hasher) {

--- a/PersonalScheduler/Sources/Model/User.swift
+++ b/PersonalScheduler/Sources/Model/User.swift
@@ -14,3 +14,16 @@ struct User: Codable {
     var profileURL: String?
     var schedules: [Schedule]?
 }
+
+extension User {
+    
+    init(_ dictinary: [String: Any]) {
+        self.userID = dictinary["userID"] as? String
+        self.socialType = dictinary["socialType"] as? String
+        self.name = dictinary["name"] as? String
+        self.profileURL = dictinary["profileURL"] as? String
+        let schedules = dictinary["schedules"] as? [[String: Any]] ?? []
+        self.schedules = schedules.map { Schedule($0) }
+    }
+    
+}

--- a/PersonalScheduler/Sources/Presentation/Schedule/Coordinator/ScheduleCoordinator.swift
+++ b/PersonalScheduler/Sources/Presentation/Schedule/Coordinator/ScheduleCoordinator.swift
@@ -16,9 +16,12 @@ final class ScheduleCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController, type: CoordinatorType) {
+    private let schedule: Schedule
+    
+    init(navigationController: UINavigationController, type: CoordinatorType, schedule: Schedule) {
         self.navigationController = navigationController
         self.type = type
+        self.schedule = schedule
     }
     
     func start() {
@@ -32,7 +35,10 @@ private extension ScheduleCoordinator {
     
     func makeScheduleViewController() -> UIViewController {
         let viewController = ScheduleViewController(
-            viewModel: ScheduleViewModel(),
+            viewModel: DefaultScheduleViewModel(
+                schedule: schedule,
+                type: type == .create ? .create : .edit
+            ),
             coordinator: self,
             type: type == .create ? .create : .edit
         )

--- a/PersonalScheduler/Sources/Presentation/Schedule/ViewController/ScheduleViewController.swift
+++ b/PersonalScheduler/Sources/Presentation/Schedule/ViewController/ScheduleViewController.swift
@@ -110,7 +110,6 @@ class ScheduleViewController: UIViewController {
     private lazy var endDateSettingView: DateSettingView = {
         let view = DateSettingView()
         view.setUp(Date().nearestHour().plusHour(1))
-        view.highlight(.systemRed)
         let tap = UITapGestureRecognizer()
         tap.addTarget(self, action: #selector(didTapEndDate(_:)))
         view.addGestureRecognizer(tap)

--- a/PersonalScheduler/Sources/Presentation/Schedule/ViewModel/ScheduleViewModel.swift
+++ b/PersonalScheduler/Sources/Presentation/Schedule/ViewModel/ScheduleViewModel.swift
@@ -6,7 +6,163 @@
 //
 
 import Foundation
+import Combine
 
-final class ScheduleViewModel {
+protocol ScheduleViewModelInput {
     
+    func viewDidLoad()
+    func didTapSaveButton(title: String, description: String)
+    func didChangeStartDate(_ date: Date)
+    func didChangeEndDate(_ date: Date)
+    
+}
+
+protocol ScheduleViewModelOutput {
+    
+    var title: AnyPublisher<String?, Never> { get }
+    var startDate: AnyPublisher<Date, Never> { get }
+    var endDate: AnyPublisher<Date, Never> { get }
+    var description: AnyPublisher<String?, Never> { get }
+    var isValidDate: AnyPublisher<Bool, Never> { get }
+    var isLoading: AnyPublisher<Bool, Never> { get }
+    var errorMessage: AnyPublisher<String?, Never> { get }
+    var isCompleted: AnyPublisher<Bool, Never> { get }
+    var currentStartData: Date { get }
+    var currentEndData: Date { get }
+
+}
+
+protocol ScheduleViewModel {
+    
+    var input: ScheduleViewModelInput { get }
+    var output: ScheduleViewModelOutput { get }
+    
+    var cancellables: Set<AnyCancellable> { get }
+    
+}
+
+final class DefaultScheduleViewModel: ScheduleViewModel {
+    
+    private(set) var cancellables: Set<AnyCancellable> = .init()
+    private let type: ScheduleViewController.ViewType
+    private var _schedule: Schedule
+    
+    private let scheduleRepository: ScheduleRepository
+
+    private var _title = CurrentValueSubject<String?, Never>(nil)
+    private var _startDate = CurrentValueSubject<Date, Never>(Date().nearestHour())
+    private var _endDate = CurrentValueSubject<Date, Never>(Date().nearestHour().plusHour(1))
+    private var _description = CurrentValueSubject<String?, Never>(nil)
+    private var _isValidDate =  CurrentValueSubject<Bool, Never>(true)
+    private var _isLoading =  CurrentValueSubject<Bool, Never>(true)
+    private var _errorMessage =  CurrentValueSubject<String?, Never>(nil)
+    private var _isCompleted = CurrentValueSubject<Bool, Never>(false)
+    
+    init(
+        schedule: Schedule,
+        type: ScheduleViewController.ViewType,
+        scheduleRepository: ScheduleRepository = DefaultScheduleRepository()
+    ) {
+        self._schedule = schedule
+        self.type = type
+        self.scheduleRepository = scheduleRepository
+    }
+}
+
+private extension DefaultScheduleViewModel {
+    
+    func errorhandling(_ error: Error, message: String) {
+        debugPrint(error)
+        _errorMessage.send(message)
+    }
+    
+}
+
+extension DefaultScheduleViewModel: ScheduleViewModelInput {
+    
+    var input: ScheduleViewModelInput { self }
+
+    func viewDidLoad() {
+        switch type {
+        case .edit:
+            _title.send(_schedule.title)
+            _startDate.send(_schedule.startDate)
+            _endDate.send(_schedule.endDate)
+            _description.send(_schedule.description)
+        default: break
+        }
+        _isLoading.send(false)
+    }
+    
+    func didTapSaveButton(title: String, description: String) {
+        guard title.count >= 1 else {
+            _errorMessage.send("일정 제목 입력은 필수입니다.")
+            return
+        }
+        _isLoading.send(true)
+        let newSchedule = Schedule(
+            id: type == .create ? UUID().uuidString : _schedule.id,
+            title: title,
+            startDate: _startDate.value,
+            endDate: _endDate.value,
+            description: description
+        )
+        switch type {
+        case .edit:
+            scheduleRepository.update(schedule: newSchedule)
+                .sink(receiveCompletion: { [weak self] complection in
+                    if case let .failure(error) = complection {
+                        self?.errorhandling(error, message: "일정을 저장하는 도중에 알 수 없는 에러가 발생했습니다.")
+                    }
+                    self?._isLoading.send(false)
+                }, receiveValue: { [weak self] isSuccess in
+                    self?._isCompleted.send(isSuccess)
+                }).store(in: &cancellables)
+        case .create:
+            scheduleRepository.write(schedule: newSchedule)
+                .sink(receiveCompletion: { [weak self] complection in
+                    if case let .failure(error) = complection {
+                        self?.errorhandling(error, message: "새 일정을 등록하는 도중에 알 수 없는 에러가 발생했습니다.")
+                    }
+                self?._isLoading.send(false)
+                }, receiveValue: { [weak self] isSuccess in
+                    self?._isCompleted.send(isSuccess)
+                }).store(in: &cancellables)
+        }
+    }
+    
+    func didChangeStartDate(_ date: Date) {
+        _startDate.send(date)
+        if _endDate.value.isFuture(from: date) {
+            _isValidDate.send(false)
+        } else {
+            _isValidDate.send(true)
+        }
+    }
+    
+    func didChangeEndDate(_ date: Date) {
+        _endDate.send(date)
+        if date.isFuture(from: _startDate.value) {
+            _isValidDate.send(false)
+        } else {
+            _isValidDate.send(true)
+        }
+    }
+}
+
+extension DefaultScheduleViewModel: ScheduleViewModelOutput {
+    
+    var output: ScheduleViewModelOutput { self }
+    
+    var title: AnyPublisher<String?, Never> { _title.eraseToAnyPublisher() }
+    var startDate: AnyPublisher<Date, Never> { _startDate.eraseToAnyPublisher() }
+    var endDate: AnyPublisher<Date, Never> { _endDate.eraseToAnyPublisher() }
+    var description: AnyPublisher<String?, Never> { _description.eraseToAnyPublisher() }
+    var isValidDate: AnyPublisher<Bool, Never> { _isValidDate.eraseToAnyPublisher() }
+    var isLoading: AnyPublisher<Bool, Never> { _isLoading.eraseToAnyPublisher() }
+    var errorMessage: AnyPublisher<String?, Never> { _errorMessage.eraseToAnyPublisher() }
+    var isCompleted: AnyPublisher<Bool, Never> { _isCompleted.eraseToAnyPublisher() }
+    var currentStartData: Date { _startDate.value }
+    var currentEndData: Date { _endDate.value }
+
 }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/Coordinator/ScheduleListCoordinator.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/Coordinator/ScheduleListCoordinator.swift
@@ -38,13 +38,13 @@ private extension ScheduleListCoordinator {
     }
     
     
-    func makeScheduleCoordinator(type: CoordinatorType) -> Coordinator? {
+    func makeScheduleCoordinator(type: CoordinatorType, schedule: Schedule) -> Coordinator? {
         let coordinator: ScheduleCoordinator
         switch type {
         case .create:
-            coordinator = ScheduleCoordinator(navigationController: .init(), type: type)
+            coordinator = ScheduleCoordinator(navigationController: .init(), type: type, schedule: schedule)
         case .edit:
-            coordinator = ScheduleCoordinator(navigationController: navigationController, type: type)
+            coordinator = ScheduleCoordinator(navigationController: navigationController, type: type, schedule: schedule)
         default: return nil
         }
         coordinator.finishDelegate = self
@@ -74,7 +74,7 @@ extension ScheduleListCoordinator: CoordinatorFinishDelegate {
 extension ScheduleListCoordinator: ScheduleListCoordinatorInterface {
     
     func showCreateSchedule() {
-        let coordinator = makeScheduleCoordinator(type: .create)
+        let coordinator = makeScheduleCoordinator(type: .create, schedule: Schedule())
         coordinator?.start()
         let viewController = coordinator?.navigationController ?? UIViewController()
         viewController.modalPresentationStyle = .fullScreen
@@ -82,7 +82,7 @@ extension ScheduleListCoordinator: ScheduleListCoordinatorInterface {
     }
     
     func showEditSchedule(_ schedule: Schedule) {
-        let coordinator = makeScheduleCoordinator(type: .edit)
+        let coordinator = makeScheduleCoordinator(type: .edit, schedule: schedule)
         coordinator?.start()
     }
 }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/View/NavigationTitleView.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/View/NavigationTitleView.swift
@@ -18,7 +18,6 @@ final class NavigationTitleView: UIStackView {
         label.textColor = .label
         label.font = .preferredFont(for: .body, weight: .bold)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -48,4 +47,11 @@ final class NavigationTitleView: UIStackView {
         addArrangedSubviews(titleLabel, arrowButton)
     }
     
+}
+
+extension NavigationTitleView {
+    
+    func update(title: String) {
+        titleLabel.text = title
+    }
 }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
@@ -122,12 +122,9 @@ extension ScheduleCell {
     
     func setUp(_ schedule: Schedule) {
         dateView.setUp(schedule.startDate)
+        setUpDateLabel(schedule)
         titleLabel.text = schedule.title
         descriptionLabel.text = schedule.description
-        dateLabel.text = "\(schedule.startDate.toString(.hourMinute)) - \(schedule.endDate.toString(.hourMinute))"
-        if schedule.isProgressing {
-            highlight()
-        }
     }
     
     func highlight() {
@@ -172,6 +169,15 @@ private extension ScheduleCell {
         dateLabel.text = nil
         topSeparatorView.isHidden = true
         monthLabel.isHidden = true
+    }
+    
+    func setUpDateLabel(_ schedule: Schedule) {
+        let start = schedule.startDate.toString(.hourMinute)
+        let end = schedule.endDate.toString(schedule.hasOneMoreDay ? .hourMinuteDate : .hourMinute)
+        dateLabel.text = "\(start) - \(end)"
+        if schedule.isProgressing {
+            highlight()
+        }
     }
     
 }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
@@ -10,9 +10,9 @@ import UIKit
 final class ScheduleCell: UICollectionViewCell {
     
     private lazy var backgroundStackView: UIStackView = {
-        let stackView = UIStackView(axis: .horizontal, alignment: .center, distribution: .fill, spacing: 20)
+        let stackView = UIStackView(axis: .vertical, alignment: .leading, distribution: .fill, spacing: 20)
         stackView.backgroundColor = .clear
-        stackView.addArrangedSubviews(dateView, colorSeparatorView, scheduleView)
+        stackView.addArrangedSubviews(monthLabel, topSeparatorView, infoStackView)
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 20,
@@ -23,7 +23,14 @@ final class ScheduleCell: UICollectionViewCell {
         return stackView
     }()
     
-    private lazy var separatorView: UIView = {
+    private lazy var infoStackView: UIStackView = {
+        let stackView = UIStackView(axis: .horizontal, alignment: .center, distribution: .fill, spacing: 20)
+        stackView.backgroundColor = .clear
+        stackView.addArrangedSubviews(dateView, colorSeparatorView, scheduleView)
+        return stackView
+    }()
+    
+    private lazy var bottomseparatorView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemGray4
         view.heightAnchor.constraint(equalToConstant: 0.3).isActive = true
@@ -76,6 +83,25 @@ final class ScheduleCell: UICollectionViewCell {
         return view
     }()
     
+    private lazy var monthLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .label
+        label.font = .preferredFont(for: .body, weight: .bold)
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.isHidden = true
+        return label
+    }()
+    
+    
+    private lazy var topSeparatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray4
+        view.heightAnchor.constraint(equalToConstant: 0.3).isActive = true
+        view.widthAnchor.constraint(equalToConstant: safeAreaLayoutGuide.layoutFrame.width - 40).isActive = true
+        view.isHidden = true
+        return view
+    }()
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         reset()
@@ -109,22 +135,28 @@ extension ScheduleCell {
         colorSeparatorView.backgroundColor = .psToday
     }
     
+    func showMonthView(_ date: Date) {
+        topSeparatorView.isHidden = false
+        monthLabel.isHidden = false
+        monthLabel.text = date.toString(.yearAndMonth)
+    }
+    
 }
 
 private extension ScheduleCell {
     
     func configure() {
         contentView.backgroundColor = .psBackground
-        contentView.addSubviews(backgroundStackView, separatorView)
+        contentView.addSubviews(backgroundStackView, bottomseparatorView)
         let constraints: [NSLayoutConstraint] = [
             backgroundStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             backgroundStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             backgroundStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             backgroundStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            separatorView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            colorSeparatorView.heightAnchor.constraint(equalTo: backgroundStackView.heightAnchor, constant: -40)
+            bottomseparatorView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            bottomseparatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            bottomseparatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            colorSeparatorView.heightAnchor.constraint(equalTo: scheduleView.heightAnchor)
         ]
         constraints.forEach { constraint in
             constraint.priority = .init(999)
@@ -138,6 +170,8 @@ private extension ScheduleCell {
         titleLabel.text = nil
         descriptionLabel.text = nil
         dateLabel.text = nil
+        topSeparatorView.isHidden = true
+        monthLabel.isHidden = true
     }
     
 }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/View/ScheduleCell.swift
@@ -99,7 +99,7 @@ extension ScheduleCell {
         titleLabel.text = schedule.title
         descriptionLabel.text = schedule.description
         dateLabel.text = "\(schedule.startDate.toString(.hourMinute)) - \(schedule.endDate.toString(.hourMinute))"
-        if Calendar.current.isDateInToday(schedule.startDate) {
+        if schedule.isProgressing {
             highlight()
         }
     }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
@@ -122,7 +122,7 @@ private extension ScheduleListViewController {
             .compactMap { $0 }
             .map { IndexPath(item: $0, section: .zero) }
             .sinkOnMainThread(receiveValue: { [weak self] indexPath in
-                self?.collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
+                self?.collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .top)
                 self?.navigationTitleView.update(
                     title: self?.viewModel.output.currentSchedule?.startDate.toString(.yearAndMonth) ?? Date().toString(.yearAndMonth)
                 )
@@ -240,7 +240,7 @@ extension ScheduleListViewController: UICollectionViewDelegate {
 
 extension ScheduleListViewController: UIScrollViewDelegate {
     
-    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let visibleRect = CGRect(origin: collectionView.contentOffset, size: collectionView.bounds.size)
         let visiblePoint = CGPoint(x: visibleRect.minX, y: visibleRect.minY)
         if let visibleIndexPath = collectionView.indexPathForItem(at: visiblePoint),

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
@@ -35,6 +35,11 @@ class ScheduleListViewController: UIViewController {
         viewModel.input.viewDidLoad()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.input.viewWillAppear()
+    }
+    
     init(viewModel: ScheduleListViewModel, coordinator: ScheduleListCoordinatorInterface) {
         self.viewModel = viewModel
         self.coordinator = coordinator

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/ViewController/ScheduleListViewController.swift
@@ -117,6 +117,13 @@ private extension ScheduleListViewController {
             .sinkOnMainThread(receiveValue: { [weak self] message in
                 self?.showAlert(message: message)
             }).store(in: &cancellables)
+        
+        viewModel.output.showSelectedDate
+            .compactMap { $0 }
+            .map { IndexPath(item: $0, section: .zero) }
+            .sinkOnMainThread(receiveValue: { [weak self] indexPath in
+                self?.collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
+            }).store(in: &cancellables)
     }
     
     func setUp() {
@@ -150,7 +157,7 @@ private extension ScheduleListViewController {
     }
     
     @objc func didTapNavigationTitle(_ gesture: UITapGestureRecognizer) {
-        showDatePickerAlert(Date()) { [weak self] date in
+        showDatePickerAlert(viewModel.output.currentSelectedDate, type: .date) { [weak self] date in
             self?.viewModel.input.selectedDate(date)
         }
     }

--- a/PersonalScheduler/Sources/Presentation/ScheduleList/ViewModel/ScheduleListViewModel.swift
+++ b/PersonalScheduler/Sources/Presentation/ScheduleList/ViewModel/ScheduleListViewModel.swift
@@ -23,6 +23,7 @@ protocol ScheduleListViewModelOutput {
     var errorMessage: AnyPublisher<String?, Never> { get }
     var isLoading: AnyPublisher<Bool, Never> { get }
     var currentSelectedDate: Date { get }
+    var showSelectedDate: AnyPublisher<Int?, Never> { get }
     
 }
 
@@ -45,6 +46,7 @@ final class DefaultScheduleListViewModel: ScheduleListViewModel {
     private var _errorMessage = CurrentValueSubject<String?, Never>(nil)
     private var _isLoading = CurrentValueSubject<Bool, Never>(true)
     private var _currentSelectedDate = CurrentValueSubject<Date, Never>(Date())
+    private var _showSelectedDate = CurrentValueSubject<Int?, Never>(nil)
     
     private var _currentSchedules = [Schedule]() {
         didSet {
@@ -103,6 +105,14 @@ extension DefaultScheduleListViewModel: ScheduleListViewModelInput {
     
     func selectedDate(_ date: Date) {
         _currentSelectedDate.send(date)
+        if let index = _currentSchedules.firstIndex(where: { $0.startDate.isEqualDay(from: date)  }) {
+            _showSelectedDate.send(index)
+        } else if let index = _currentSchedules.firstIndex(where: { $0.startDate.isEqualMonth(from: date) }) {
+            _showSelectedDate.send(index)
+            _errorMessage.send("선택한 날짜에 일정이 존재하지 않습니다.")
+        } else {
+            _errorMessage.send("선택한 날짜에 일정이 존재하지 않습니다.")
+        }
     }
 }
 
@@ -114,5 +124,6 @@ extension DefaultScheduleListViewModel: ScheduleListViewModelOutput {
     var errorMessage: AnyPublisher<String?, Never> { _errorMessage.eraseToAnyPublisher() }
     var isLoading: AnyPublisher<Bool, Never> { _isLoading.eraseToAnyPublisher() }
     var currentSelectedDate: Date { _currentSelectedDate.value }
+    var showSelectedDate: AnyPublisher<Int?, Never> { _showSelectedDate.eraseToAnyPublisher() }
 
 }

--- a/PersonalScheduler/Sources/Storages/FirestoreStorage.swift
+++ b/PersonalScheduler/Sources/Storages/FirestoreStorage.swift
@@ -55,7 +55,7 @@ final class FirestoreStorage: FirestoreStorageService {
     
     func write(user: User) -> AnyPublisher<Bool, Error> {
         let completed = PassthroughSubject<Bool, Error>()
-        guard let userID = user.userID, let user = try? user.asDictionary() else {
+        guard let userID = user.userID, let user = try? user.asFirestoreDictionary() else {
             return Empty().eraseToAnyPublisher()
         }
         database.collection("User")
@@ -81,7 +81,7 @@ final class FirestoreStorage: FirestoreStorageService {
     
     func update(user: User) -> AnyPublisher<Bool, Error> {
         let completed = PassthroughSubject<Bool, Error>()
-        guard let userID = user.userID, let user = try? user.asDictionary() else {
+        guard let userID = user.userID, let user = try? user.asFirestoreDictionary() else {
             return Empty().eraseToAnyPublisher()
         }
         database.collection("User")

--- a/PersonalScheduler/Sources/Storages/LocalStorage.swift
+++ b/PersonalScheduler/Sources/Storages/LocalStorage.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
 
 enum LocalKey: String {
     case userInfo = "userInfo"
@@ -35,17 +37,15 @@ extension UserDefaults: LocalStorageService {
     }
     
     func saveUser(_ user: User) {
-        let encoder = JSONEncoder()
+        let encoder = Firestore.Encoder()
         let encodedUser = try? encoder.encode(user)
         Self.standard.setValue(encodedUser, forKey: LocalKey.userInfo.rawValue)
         Self.standard.synchronize()
     }
     
     func getUser() -> User? {
-        if let data = Self.standard.object(forKey: LocalKey.userInfo.rawValue) as? Data {
-            let decoder = JSONDecoder()
-            let savedUser = try? decoder.decode(User.self, from: data)
-                return savedUser
+        if let dittionary = Self.standard.object(forKey: LocalKey.userInfo.rawValue) as? [String: Any] {
+            return User(dittionary)
             
         }
         return nil


### PR DESCRIPTION
- firestore에 유저 정보를 저장, 업데이트, 삭제할 때의 로직을 개선
- 스케줄 목록 화면 개선
- 날짜 선택 시 해당 날짜로 스크롤 하는 기능 구현
	- 동일한 달이 아니라면 별도로 표시하도록 구현 (예외 케이스)
	- 일정이 하루 이상 길어진다면 별도로 표시하도록 구현 (예외 케이스)
	- 스크롤 시 현재 사용자가 보고있는 날짜를 화면에 반영하도록 구현